### PR TITLE
Auth enhancements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 ## Other
 
+- Add a vignette "Using Microsoft365R in a Shiny app" for this common use case.
+- Make `token` an explicit argument to the client functions, for supplying an OAuth token object directly. Note that this was always possible, but is now better documented and supported. This is mostly to support the Shiny use case, as well as other situations where authentication is more complicated than usual.
 - Changes to allow Microsoft365R to be usable without being on the search list (#72). Among other things, `make_basic_list()` is now a private method, rather than being exported. Thanks to Robert Ashton (@r-ash) for the PR.
 
 # Microsoft365R 2.3.0

--- a/R/client.R
+++ b/R/client.R
@@ -9,7 +9,7 @@
 #' @param team_name,team_id For `get_team`, either the name or ID of the team to retrieve. Supply exactly one of these.
 #' @param shared_mbox_id,shared_mbox_name,shared_mbox_email For `get_business_outlook`, an ID/principal name/email address. Supply exactly one of these to retrieve a shared mailbox. If all are NULL (the default), retrieve your own mailbox.
 #' @param chat_id For `get_chat`, the ID of a group, one-on-one or meeting chat in Teams.
-#' @param token An AAD OAuth token object, of class `AzureAuth::AzureToken`. If supplied, this will override any other arguments. See "AUthenticating with a token" below.
+#' @param token An AAD OAuth token object, of class `AzureAuth::AzureToken`. If supplied, the `tenant`, `app`, `scopes` and `...` arguments will be ignored. See "Authenticating with a token" below.
 #' @param ... Optional arguments that will ultimately be passed to [`AzureAuth::get_azure_token`].
 #' @details
 #' These functions provide easy access to the various collaboration services that are part of Microsoft 365. On first use, they will call your web browser to authenticate with Azure Active Directory, in a similar manner to other web apps. You will get a dialog box asking for permission to access your information. You only have to authenticate once; your credentials will be saved and reloaded in subsequent sessions.
@@ -258,7 +258,7 @@ do_login <- function(tenant, app, scopes, token, ...)
 {
     # bypass AzureGraph login caching if token provided
     if(!is.null(token))
-        return(msgraph$new(token=token))
+        return(ms_graph$new(token=token))
 
     login <- try(get_graph_login(tenant, app=app, scopes=scopes, refresh=FALSE), silent=TRUE)
     if(inherits(login, "try-error"))

--- a/R/client.R
+++ b/R/client.R
@@ -251,29 +251,15 @@ list_chats <- function(tenant=Sys.getenv("CLIMICROSOFT365_TENANT", "common"),
 }
 
 
-.ms365_login_env <- new.env()
-
 do_login <- function(tenant, app, scopes, token, ...)
 {
-    hash <- function(...)
-    {
-        as.character(openssl::md5(serialize(list(...), NULL)))
-    }
+    # bypass AzureGraph login caching if token provided
+    if(!is.null(token))
+        return(msgraph$new(token=token))
 
-    login_id <- hash(tenant, app, scopes, token, ...)
-    login <- .ms365_login_env[[login_id]]
-    if(is.null(login) || !inherits(login, "ms_graph"))
-    {
-        if(!is.null(token))
-            login <- token
-        else
-        {
-            login <- try(get_graph_login(tenant, app=app, scopes=scopes, refresh=FALSE), silent=TRUE)
-            if(inherits(login, "try-error"))
-                login <- create_graph_login(tenant, app=app, scopes=scopes, ...)
-        }
-        .ms365_login_env[[login_id]] <- login
-    }
+    login <- try(get_graph_login(tenant, app=app, scopes=scopes, refresh=FALSE), silent=TRUE)
+    if(inherits(login, "try-error"))
+        login <- create_graph_login(tenant, app=app, scopes=scopes, ...)
     login
 }
 

--- a/R/client.R
+++ b/R/client.R
@@ -16,19 +16,22 @@
 #'
 #' When authenticating, you can pass optional arguments in `...` which will ultimately be received by `AzureAuth::get_azure_token`. In particular, if your machine doesn't have a web browser available to authenticate with (for example if you are in a remote RStudio Server session), pass `auth_type="device_code"` which is intended for such scenarios.
 #'
-#' @section Authenticating to Microsoft 365 Business services:
+#' ## Authenticating to Microsoft 365 Business services
 #' Authenticating to Microsoft 365 Business services (Teams, SharePoint and business OneDrive/Outlook) has some specific complexities.
 #'
 #' The default "common" tenant for `get_team`, `get_business_onedrive` and `get_sharepoint_site` attempts to detect your actual tenant from your saved credentials in your browser. This may not always succeed, for example if you have a personal account that is also a guest account in a tenant. In this case, supply the actual tenant name, either in the `tenant` argument or in the `CLIMICROSOFT365_TENANT` environment variable. The latter allows sharing authentication details with the [CLI for Microsoft 365](https://pnp.github.io/cli-microsoft365/).
 #'
 #' The default when authenticating to these services is for Microsoft365R to use its own internal app ID. As an alternative, you (or your admin) can create your own app registration in Azure: for use in a local session, it should have a native redirect URI of `http://localhost:1410`, and the "public client" option should be enabled if you want to use the device code authentication flow. You can supply your app ID either via the `app` argument, or in the environment variable `CLIMICROSOFT365_AADAPPID`.
 #'
-#' @section Authenticating with a token:
+#' ## Authenticating with a token
 #' In some circumstances, it may be desirable to carry out authentication/authorization as a separate step prior to  making requests to the Microsoft 365 REST API. This holds in a Shiny app, for example, since only the UI part can talk to the browser while the server part does the rest of the work. Another scenario is if the refresh token lifetime set by your org is too short, so that the token expires in between R sessions. In this case, you can authenticate by obtaining a new token with `AzureAuth::get_azure_token`, and passing the token object to the client function.
 #'
 #' When calling `get_azure_token`, the scopes you should use are those given in the `scopes` argument for each client function, and the API host is `https://graph.microsoft.com/`. The Microsoft365R internal app ID is `d44a05d5-c6a5-4bbb-82d2-443123722380`, while that for the CLI for Microsoft 365 is `31359c7f-bd7e-475c-86db-fdb8c937548e`. However, these app IDs **only** work for a local R session; you must create your own app registration if you want to use the package inside a Shiny app.
 #'
 #' See the examples below, and also the vignette "Using Microsoft365R in a Shiny app" for a more detailed rundown on combining Microsoft365R and Shiny.
+#'
+#' ## Clearing the cache
+#' Deleting your cached credentials is a way of rebooting the authentication process, if you are repeatedly encountering errors. To do this, call [`AzureAuth::clean_token_directory`], then try logging in again. You may also need to clear your browser's cookies, if you are authenticating interactively.
 #'
 #' @return
 #' For `get_personal_onedrive` and `get_business_onedrive`, an R6 object of class `ms_drive`.

--- a/R/client.R
+++ b/R/client.R
@@ -87,8 +87,8 @@
 #'     "openid", "offline_access"
 #' )
 #' app <- "d44a05d5-c6a5-4bbb-82d2-443123722380" # for local use only
-#' token <- AzureAuth::get_azure_token(scopes, "mytenant", app, version=2)
-#' od <- get_business_onedrive(token=token)
+#' token <- AzureAuth::get_azure_token(scopes, "mycompany", app, version=2)
+#' get_business_onedrive(token=token)
 #'
 #' }
 #' @rdname client

--- a/man/client.Rd
+++ b/man/client.Rd
@@ -107,7 +107,7 @@ list_chats(
 
 \item{scopes}{The Microsoft Graph scopes (permissions) to obtain. It should never be necessary to change these.}
 
-\item{token}{An AAD OAuth token object, of class \code{AzureAuth::AzureToken}. If supplied, this will override any other arguments. See "AUthenticating with a token" below.}
+\item{token}{An AAD OAuth token object, of class \code{AzureAuth::AzureToken}. If supplied, the \code{tenant}, \code{app}, \code{scopes} and \code{...} arguments will be ignored. See "Authenticating with a token" below.}
 
 \item{...}{Optional arguments that will ultimately be passed to \code{\link[AzureAuth:get_azure_token]{AzureAuth::get_azure_token}}.}
 

--- a/man/client.Rd
+++ b/man/client.Rd
@@ -107,7 +107,7 @@ list_chats(
 
 \item{scopes}{The Microsoft Graph scopes (permissions) to obtain. It should never be necessary to change these.}
 
-\item{token}{An AAD OAuth token object, of class \code{AzureAuth::AzureToken}. If supplied, this will override any other arguments. Mostly intended for use in Shiny apps, where authentication must be handled specially.}
+\item{token}{An AAD OAuth token object, of class \code{AzureAuth::AzureToken}. If supplied, this will override any other arguments. See "AUthenticating with a token" below.}
 
 \item{...}{Optional arguments that will ultimately be passed to \code{\link[AzureAuth:get_azure_token]{AzureAuth::get_azure_token}}.}
 
@@ -138,11 +138,20 @@ When authenticating, you can pass optional arguments in \code{...} which will ul
 }
 \section{Authenticating to Microsoft 365 Business services}{
 
-Authenticating to Microsoft 365 Business services (Teams, SharePoint and OneDrive for Business) has some specific complexities.
+Authenticating to Microsoft 365 Business services (Teams, SharePoint and business OneDrive/Outlook) has some specific complexities.
 
 The default "common" tenant for \code{get_team}, \code{get_business_onedrive} and \code{get_sharepoint_site} attempts to detect your actual tenant from your saved credentials in your browser. This may not always succeed, for example if you have a personal account that is also a guest account in a tenant. In this case, supply the actual tenant name, either in the \code{tenant} argument or in the \code{CLIMICROSOFT365_TENANT} environment variable. The latter allows sharing authentication details with the \href{https://pnp.github.io/cli-microsoft365/}{CLI for Microsoft 365}.
 
-The default when authenticating to these services is for Microsoft365R to use its own internal app ID. As an alternative, you (or your admin) can create your own app registration in Azure: it should have a native redirect URI of \verb{http://localhost:1410}, and the "public client" option should be enabled if you want to use the device code authentication flow. You can supply your app ID either via the \code{app} argument, or in the environment variable \code{CLIMICROSOFT365_AADAPPID}.
+The default when authenticating to these services is for Microsoft365R to use its own internal app ID. As an alternative, you (or your admin) can create your own app registration in Azure: for use in a local session, it should have a native redirect URI of \verb{http://localhost:1410}, and the "public client" option should be enabled if you want to use the device code authentication flow. You can supply your app ID either via the \code{app} argument, or in the environment variable \code{CLIMICROSOFT365_AADAPPID}.
+}
+
+\section{Authenticating with a token}{
+
+In some circumstances, it may be desirable to carry out authentication/authorization as a separate step prior to  making requests to the Microsoft 365 REST API. This holds in a Shiny app, for example, since only the UI part can talk to the browser while the server part does the rest of the work. Another scenario is if the refresh token lifetime set by your org is too short, so that the token expires in between R sessions. In this case, you can authenticate by obtaining a new token with \code{AzureAuth::get_azure_token}, and passing the token object to the client function.
+
+When calling \code{get_azure_token}, the scopes you should use are those given in the \code{scopes} argument for each client function, and the API host is \verb{https://graph.microsoft.com/}. The Microsoft365R internal app ID is \verb{d44a05d5-c6a5-4bbb-82d2-443123722380}, while that for the CLI for Microsoft 365 is \verb{31359c7f-bd7e-475c-86db-fdb8c937548e}. However, these app IDs \strong{only} work for a local R session; you must create your own app registration if you want to use the package inside a Shiny app.
+
+See the examples below, and also the vignette "Using Microsoft365R in a Shiny app" for a more detailed rundown on combining Microsoft365R and Shiny.
 }
 
 \examples{
@@ -178,6 +187,16 @@ get_business_onedrive()
 get_sharepoint_site("My site")
 get_team("My team")
 
+# authenticating separately to working with the MS365 API
+scopes <- c(
+    "https://graph.microsoft.com/Files.ReadWrite.All",
+    "https://graph.microsoft.com/User.Read",
+    "openid", "offline_access"
+)
+app <- "d44a05d5-c6a5-4bbb-82d2-443123722380" # for local use only
+token <- AzureAuth::get_azure_token(scopes, "mytenant", app, version=2)
+od <- get_business_onedrive(token=token)
+
 }
 }
 \seealso{
@@ -185,7 +204,7 @@ get_team("My team")
 
 \code{\link{add_methods}} for the associated methods that this package adds to the base AzureGraph classes.
 
-The "Authentication" vignette has more details on the authentication process, including troubleshooting and fixes for common problems.
+The "Authentication" vignette has more details on the authentication process, including troubleshooting and fixes for common problems. The "Using Microsoft365R in a Shiny app" vignette has further Shiny-specific information, including how to configure the necessary app registration in Azure Active Directory.
 
 \href{https://pnp.github.io/cli-microsoft365/}{CLI for Microsoft 365} -- a commandline tool for managing Microsoft 365
 }

--- a/man/client.Rd
+++ b/man/client.Rd
@@ -198,8 +198,8 @@ scopes <- c(
     "openid", "offline_access"
 )
 app <- "d44a05d5-c6a5-4bbb-82d2-443123722380" # for local use only
-token <- AzureAuth::get_azure_token(scopes, "mytenant", app, version=2)
-od <- get_business_onedrive(token=token)
+token <- AzureAuth::get_azure_token(scopes, "mycompany", app, version=2)
+get_business_onedrive(token=token)
 
 }
 }

--- a/man/client.Rd
+++ b/man/client.Rd
@@ -146,7 +146,9 @@ The default when authenticating to these services is for Microsoft365R to use it
 
 \subsection{Authenticating with a token}{
 
-In some circumstances, it may be desirable to carry out authentication/authorization as a separate step prior to  making requests to the Microsoft 365 REST API. This holds in a Shiny app, for example, since only the UI part can talk to the browser while the server part does the rest of the work. Another scenario is if the refresh token lifetime set by your org is too short, so that the token expires in between R sessions. In this case, you can authenticate by obtaining a new token with \code{AzureAuth::get_azure_token}, and passing the token object to the client function.
+In some circumstances, it may be desirable to carry out authentication/authorization as a separate step prior to  making requests to the Microsoft 365 REST API. This holds in a Shiny app, for example, since only the UI part can talk to the browser while the server part does the rest of the work. Another scenario is if the refresh token lifetime set by your org is too short, so that the token expires in between R sessions.
+
+In this case, you can authenticate by obtaining a new token with \code{AzureAuth::get_azure_token}, and passing the token object to the client function. Note that the token is accepted as-is; no checks are performed that it has the correct permissions for the service you're using.
 
 When calling \code{get_azure_token}, the scopes you should use are those given in the \code{scopes} argument for each client function, and the API host is \verb{https://graph.microsoft.com/}. The Microsoft365R internal app ID is \verb{d44a05d5-c6a5-4bbb-82d2-443123722380}, while that for the CLI for Microsoft 365 is \verb{31359c7f-bd7e-475c-86db-fdb8c937548e}. However, these app IDs \strong{only} work for a local R session; you must create your own app registration if you want to use the package inside a Shiny app.
 

--- a/man/client.Rd
+++ b/man/client.Rd
@@ -135,8 +135,7 @@ Microsoft365R provides functions for logging into each Microsoft 365 service.
 These functions provide easy access to the various collaboration services that are part of Microsoft 365. On first use, they will call your web browser to authenticate with Azure Active Directory, in a similar manner to other web apps. You will get a dialog box asking for permission to access your information. You only have to authenticate once; your credentials will be saved and reloaded in subsequent sessions.
 
 When authenticating, you can pass optional arguments in \code{...} which will ultimately be received by \code{AzureAuth::get_azure_token}. In particular, if your machine doesn't have a web browser available to authenticate with (for example if you are in a remote RStudio Server session), pass \code{auth_type="device_code"} which is intended for such scenarios.
-}
-\section{Authenticating to Microsoft 365 Business services}{
+\subsection{Authenticating to Microsoft 365 Business services}{
 
 Authenticating to Microsoft 365 Business services (Teams, SharePoint and business OneDrive/Outlook) has some specific complexities.
 
@@ -145,7 +144,7 @@ The default "common" tenant for \code{get_team}, \code{get_business_onedrive} an
 The default when authenticating to these services is for Microsoft365R to use its own internal app ID. As an alternative, you (or your admin) can create your own app registration in Azure: for use in a local session, it should have a native redirect URI of \verb{http://localhost:1410}, and the "public client" option should be enabled if you want to use the device code authentication flow. You can supply your app ID either via the \code{app} argument, or in the environment variable \code{CLIMICROSOFT365_AADAPPID}.
 }
 
-\section{Authenticating with a token}{
+\subsection{Authenticating with a token}{
 
 In some circumstances, it may be desirable to carry out authentication/authorization as a separate step prior to  making requests to the Microsoft 365 REST API. This holds in a Shiny app, for example, since only the UI part can talk to the browser while the server part does the rest of the work. Another scenario is if the refresh token lifetime set by your org is too short, so that the token expires in between R sessions. In this case, you can authenticate by obtaining a new token with \code{AzureAuth::get_azure_token}, and passing the token object to the client function.
 
@@ -154,6 +153,11 @@ When calling \code{get_azure_token}, the scopes you should use are those given i
 See the examples below, and also the vignette "Using Microsoft365R in a Shiny app" for a more detailed rundown on combining Microsoft365R and Shiny.
 }
 
+\subsection{Clearing the cache}{
+
+Deleting your cached credentials is a way of rebooting the authentication process, if you are repeatedly encountering errors. To do this, call \code{\link[AzureAuth:get_azure_token]{AzureAuth::clean_token_directory}}, then try logging in again. You may also need to clear your browser's cookies, if you are authenticating interactively.
+}
+}
 \examples{
 \dontrun{
 

--- a/man/client.Rd
+++ b/man/client.Rd
@@ -16,6 +16,7 @@
 get_personal_onedrive(
   app = .microsoft365r_app_id,
   scopes = c("Files.ReadWrite.All", "User.Read"),
+  token = NULL,
   ...
 )
 
@@ -23,6 +24,7 @@ get_business_onedrive(
   tenant = Sys.getenv("CLIMICROSOFT365_TENANT", "common"),
   app = Sys.getenv("CLIMICROSOFT365_AADAPPID"),
   scopes = c("Files.ReadWrite.All", "User.Read"),
+  token = NULL,
   ...
 )
 
@@ -34,6 +36,7 @@ get_sharepoint_site(
   app = Sys.getenv("CLIMICROSOFT365_AADAPPID"),
   scopes = c("Group.ReadWrite.All", "Directory.Read.All", "Sites.ReadWrite.All",
     "Sites.Manage.All"),
+  token = NULL,
   ...
 )
 
@@ -42,6 +45,7 @@ list_sharepoint_sites(
   app = Sys.getenv("CLIMICROSOFT365_AADAPPID"),
   scopes = c("Group.ReadWrite.All", "Directory.Read.All", "Sites.ReadWrite.All",
     "Sites.Manage.All"),
+  token = NULL,
   ...
 )
 
@@ -51,6 +55,7 @@ get_team(
   tenant = Sys.getenv("CLIMICROSOFT365_TENANT", "common"),
   app = Sys.getenv("CLIMICROSOFT365_AADAPPID"),
   scopes = c("Group.ReadWrite.All", "Directory.Read.All"),
+  token = NULL,
   ...
 )
 
@@ -58,12 +63,14 @@ list_teams(
   tenant = Sys.getenv("CLIMICROSOFT365_TENANT", "common"),
   app = Sys.getenv("CLIMICROSOFT365_AADAPPID"),
   scopes = c("Group.ReadWrite.All", "Directory.Read.All"),
+  token = NULL,
   ...
 )
 
 get_personal_outlook(
   app = .microsoft365r_app_id,
   scopes = c("Mail.Send", "Mail.ReadWrite", "User.Read"),
+  token = NULL,
   ...
 )
 
@@ -74,6 +81,7 @@ get_business_outlook(
   shared_mbox_name = NULL,
   shared_mbox_email = NULL,
   scopes = c("User.Read", "Mail.Send", "Mail.ReadWrite"),
+  token = NULL,
   ...
 )
 
@@ -82,6 +90,7 @@ get_chat(
   tenant = Sys.getenv("CLIMICROSOFT365_TENANT", "common"),
   app = .microsoft365r_app_id,
   scopes = c("User.Read", "Directory.Read.All", "Chat.ReadWrite"),
+  token = NULL,
   ...
 )
 
@@ -89,6 +98,7 @@ list_chats(
   tenant = Sys.getenv("CLIMICROSOFT365_TENANT", "common"),
   app = .microsoft365r_app_id,
   scopes = c("User.Read", "Directory.Read.All", "Chat.ReadWrite"),
+  token = NULL,
   ...
 )
 }
@@ -96,6 +106,8 @@ list_chats(
 \item{app}{A custom app registration ID to use for authentication. See below.}
 
 \item{scopes}{The Microsoft Graph scopes (permissions) to obtain. It should never be necessary to change these.}
+
+\item{token}{An AAD OAuth token object, of class \code{AzureAuth::AzureToken}. If supplied, this will override any other arguments. Mostly intended for use in Shiny apps, where authentication must be handled specially.}
 
 \item{...}{Optional arguments that will ultimately be passed to \code{\link[AzureAuth:get_azure_token]{AzureAuth::get_azure_token}}.}
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -25,3 +25,24 @@ filter_esc <- function(x)
     gsub("'", "''", x)
 }
 
+get_test_token <- function(tenant, app, scopes, ...)
+{
+    # if using MS365 CLI or Azure CLI app IDs...
+    # - with org tenant: set to .default scope
+    # - with consumers tenant: fail
+    consumers_tenant <- tenant %in% c("consumers", "9188040d-6c67-4c5b-b112-36a304b66dad")
+    special_app <- app %in% c("31359c7f-bd7e-475c-86db-fdb8c937548e", "04b07795-8ddb-461a-bbee-02f9e1bf7b46")
+    if(special_app)
+    {
+        if(consumers_tenant)
+            return(NULL)
+        else scopes <- ".default"
+    }
+
+    scopes <- c(file.path("https://graph.microsoft.com", scopes), "openid", "offline_access")
+    tok <- try(AzureAuth::get_azure_token(scopes, tenant, app, ..., version=2), silent=TRUE)
+    if(inherits(tok, "try-error"))
+        return(NULL)
+    tok
+}
+

--- a/tests/testthat/test00_auth.R
+++ b/tests/testthat/test00_auth.R
@@ -1,0 +1,64 @@
+app <- Sys.getenv("AZ_TEST_NATIVE_APP_ID")
+
+if(app == "")
+    skip("Authentication tests skipped: Microsoft Graph credentials not set")
+
+if(!interactive())
+    skip("OneDrive tests skipped: must be in interactive session")
+
+
+scopes <- c("Files.ReadWrite.All", "User.Read")
+
+test_that("Authenticating works with consumers tenant",
+{
+    tenant <- "consumers"
+
+    tok <- get_test_token(tenant, app, scopes)
+    if(is.null(tok))
+        skip("Consumer tenant tests skipped: unable to login to consumers tenant")
+
+    drv <- try(call_graph_endpoint(tok, "me/drive"), silent=TRUE)
+    if(inherits(drv, "try-error"))
+        skip("Consumer tenant tests skipped: service not available")
+
+    expect_type(drv, "list")
+    expect_true("id" %in% names(drv) && is.character(drv$id) && nchar(drv$id) > 0)
+
+    gr <- do_login(tenant, app, scopes, NULL)
+    expect_is(gr, "ms_graph")
+
+    drv2 <- gr$call_graph_endpoint("me/drive")
+
+    expect_type(drv2, "list")
+    expect_true("id" %in% names(drv2) && is.character(drv2$id) && nchar(drv2$id) > 0)
+    expect_identical(drv$properties$id, drv2$properties$id)
+})
+
+
+test_that("Authenticating works with org tenant",
+{
+    tenant <- Sys.getenv("AZ_TEST_TENANT_ID")
+    if(tenant == "")
+        skip("Authentication tests skipped: Microsoft Graph credentials not set")
+
+    tok <- get_test_token(tenant, app, scopes)
+    if(is.null(tok))
+        skip("Org tenant tests skipped: unable to login to consumers tenant")
+
+    drv <- try(call_graph_endpoint(tok, "me/drive"), silent=TRUE)
+    if(inherits(drv, "try-error"))
+        skip("Org tenant tests skipped: service not available")
+
+    expect_type(drv, "list")
+    expect_true("id" %in% names(drv) && is.character(drv$id) && nchar(drv$id) > 0)
+
+    gr <- do_login(tenant, app, scopes, NULL)
+    expect_is(gr, "ms_graph")
+
+    drv2 <- gr$call_graph_endpoint("me/drive")
+
+    expect_type(drv2, "list")
+    expect_true("id" %in% names(drv2) && is.character(drv2$id) && nchar(drv2$id) > 0)
+    expect_identical(drv$properties$id, drv2$properties$id)
+})
+

--- a/tests/testthat/test00_auth.R
+++ b/tests/testthat/test00_auth.R
@@ -52,6 +52,10 @@ test_that("Authenticating works with org tenant",
     expect_type(drv, "list")
     expect_true("id" %in% names(drv) && is.character(drv$id) && nchar(drv$id) > 0)
 
+    # munging of app/scopes may be required for org tenants
+    app <- choose_app(app)
+    scopes <- set_default_scopes(scopes, app)
+
     gr <- do_login(tenant, app, scopes, NULL)
     expect_is(gr, "ms_graph")
 

--- a/tests/testthat/test00a_auth_onedrive.R
+++ b/tests/testthat/test00a_auth_onedrive.R
@@ -1,0 +1,22 @@
+tenant <- "consumers"
+app <- Sys.getenv("AZ_TEST_NATIVE_APP_ID")
+
+if(app == "")
+    skip("OneDrive authentication tests skipped: Microsoft Graph credentials not set")
+
+if(!interactive())
+    skip("OneDrive authentication tests skipped: must be in interactive session")
+
+tok <- get_test_token(tenant, app, c("Files.ReadWrite.All", "User.Read"))
+if(is.null(tok))
+    skip("OneDrive authentication tests skipped: unable to login to consumers tenant")
+
+test_that("OneDrive authentication works",
+{
+    drv <- get_personal_onedrive(token=tok)
+    expect_is(drv, "ms_drive")
+
+    drv2 <- get_personal_onedrive(app=app)
+    expect_is(drv2, "ms_drive")
+    expect_identical(drv$properties$id, drv2$properties$id)
+})

--- a/tests/testthat/test00b_auth_business_onedrive.R
+++ b/tests/testthat/test00b_auth_business_onedrive.R
@@ -1,0 +1,26 @@
+tenant <- Sys.getenv("AZ_TEST_TENANT_ID")
+app <- Sys.getenv("AZ_TEST_NATIVE_APP_ID")
+
+if(tenant == "" || app == "")
+    skip("OneDrive for Business authentication tests skipped: Microsoft Graph credentials not set")
+
+if(!interactive())
+    skip("OneDrive for Business authentication tests skipped: must be in interactive session")
+
+tok <- get_test_token(tenant, app, c("Files.ReadWrite.All", "User.Read"))
+if(is.null(tok))
+    skip("OneDrive for Business authentication tests skipped: no access to tenant")
+
+drv <- try(call_graph_endpoint(tok, "me/drive"), silent=TRUE)
+if(inherits(drv, "try-error"))
+    skip("OneDrive for Business tests skipped: service not available")
+
+test_that("OneDrive authentication works",
+{
+    drv <- get_business_onedrive(token=tok)
+    expect_is(drv, "ms_drive")
+
+    drv2 <- get_business_onedrive(tenant=tenant, app=app)
+    expect_is(drv2, "ms_drive")
+    expect_identical(drv$properties$id, drv2$properties$id)
+})

--- a/tests/testthat/test00c_auth_sharepoint.R
+++ b/tests/testthat/test00c_auth_sharepoint.R
@@ -1,0 +1,59 @@
+tenant <- Sys.getenv("AZ_TEST_TENANT_ID")
+app <- Sys.getenv("AZ_TEST_NATIVE_APP_ID")
+site_name <- Sys.getenv("AZ_TEST_SHAREPOINT_SITE_NAME")
+site_url <- Sys.getenv("AZ_TEST_SHAREPOINT_SITE_URL")
+site_id <- Sys.getenv("AZ_TEST_SHAREPOINT_SITE_ID")
+
+if(tenant == "" || app == "" || site_name == "" || site_url == "" || site_id == "")
+    skip("SharePoint tests skipped: Microsoft Graph credentials not set")
+
+if(!interactive())
+    skip("SharePoint authentication tests skipped: must be in interactive session")
+
+tok <- get_test_token(tenant, app, c("Group.ReadWrite.All", "Directory.Read.All",
+                                     "Sites.ReadWrite.All", "Sites.Manage.All"))
+if(is.null(tok))
+    skip("SharePoint authentication tests skipped: no access to tenant")
+
+site <- try(call_graph_endpoint(tok, file.path("sites", site_id)), silent=TRUE)
+if(inherits(site, "try-error"))
+    skip("SharePoint authentication tests skipped: service not available")
+
+test_that("Sharepoint authentication works",
+{
+    site <- get_sharepoint_site(site_id=site_id, token=tok)
+    expect_is(site, "ms_site")
+
+    sitelist <- list_sharepoint_sites(token=tok)
+    expect_is(sitelist, "list")
+    expect_true(all(sapply(sitelist, inherits, "ms_site")))
+
+    sitelist2 <- list_sharepoint_sites(tenant=tenant, app=app)
+    expect_is(sitelist2, "list")
+    expect_true(all(sapply(sitelist2, inherits, "ms_site")))
+    expect_true(all(mapply(
+        function(s1, s2) identical(s1$properties$id, s2$properties$id,
+        sitelist1,
+        sitelist2
+    ))))
+
+    site2 <- get_sharepoint_site(site_name=site_name, token=tok)
+    expect_is(site2, "ms_site")
+    expect_identical(site$properties$id, site2$properties$id)
+
+    site3 <- get_sharepoint_site(site_url=site_url, token=tok)
+    expect_is(site3, "ms_site")
+    expect_identical(site$properties$id, site3$properties$id)
+
+    site4 <- get_sharepoint_site(site_id=site_id, tenant=tenant, app=app)
+    expect_is(site4, "ms_site")
+    expect_identical(site$properties$id, site4$properties$id)
+
+    site5 <- get_sharepoint_site(site_url=site_url, tenant=tenant, app=app)
+    expect_is(site5, "ms_site")
+    expect_identical(site$properties$id, site5$properties$id)
+
+    site6 <- get_sharepoint_site(site_name=site_name, tenant=tenant, app=app)
+    expect_is(site6, "ms_site")
+    expect_identical(site$properties$id, site6$properties$id)
+})

--- a/tests/testthat/test00d_auth_teams.R
+++ b/tests/testthat/test00d_auth_teams.R
@@ -1,0 +1,48 @@
+tenant <- Sys.getenv("AZ_TEST_TENANT_ID")
+app <- Sys.getenv("AZ_TEST_NATIVE_APP_ID")
+team_name <- Sys.getenv("AZ_TEST_TEAM_NAME")
+team_id <- Sys.getenv("AZ_TEST_TEAM_ID")
+
+if(tenant == "" || app == "" || team_name == "" || team_id == "")
+    skip("Teams authentication tests skipped: Microsoft Graph credentials not set")
+
+if(!interactive())
+    skip("Teams authentication tests skipped: must be in interactive session")
+
+tok <- get_test_token(tenant, app, c("Group.ReadWrite.All", "Directory.Read.All"))
+if(is.null(tok))
+    skip("Teams authentication tests skipped: no access to tenant")
+
+team <- try(call_graph_endpoint(tok, file.path("teams", team_id)), silent=TRUE)
+if(inherits(team, "try-error"))
+    skip("Teams authentication tests skipped: service not available")
+
+test_that("Teams authentication works",
+{
+    team <- get_team(team_id=team_id, token=tok)
+    expect_is(team, "ms_team")
+
+    teamlist <- list_teams(token=tok)
+    expect_is(teamlist, "list")
+
+    teamlist2 <- list_teams(tenant=tenant, app=app)
+    expect_is(teamlist2, "list")
+    expect_true(all(sapply(teamlist2, inherits, "ms_team")))
+    expect_true(all(mapply(
+        function(s1, s2) identical(s1$properties$id, s2$properties$id,
+        teamlist1,
+        teamlist2
+    ))))
+
+    team2 <- get_team(team_name=team_name, token=tok)
+    expect_is(team2, "ms_team")
+    expect_identical(team$properties$id, team2$properties$id)
+
+    team3 <- get_team(team_id=team_id, tenant=tenant, app=app)
+    expect_is(team3, "ms_team")
+    expect_identical(team$properties$id, team3$properties$id)
+
+    team4 <- get_team(team_name=team_name, tenant=tenant, app=app)
+    expect_is(team4, "ms_team")
+    expect_identical(team$properties$id, team4$properties$id)
+})

--- a/tests/testthat/test00e_auth_outlook.R
+++ b/tests/testthat/test00e_auth_outlook.R
@@ -1,0 +1,26 @@
+tenant <- "consumers"
+app <- Sys.getenv("AZ_TEST_NATIVE_APP_ID")
+
+if(app == "")
+    skip("Outlook authentication tests skipped: Microsoft Graph credentials not set")
+
+if(!interactive())
+    skip("Outlook authentication tests skipped: must be in interactive session")
+
+tok <- get_test_token(tenant, app, c("Mail.Send", "Mail.ReadWrite", "User.Read"))
+if(is.null(tok))
+    skip("Outlook authentication tests skipped: unable to login to consumers tenant")
+
+inbox <- try(call_graph_endpoint(tok, "me/mailFolders/inbox"), silent=TRUE)
+if(inherits(inbox, "try-error"))
+    skip("Outlook authentication tests skipped: service not available")
+
+test_that("Outlook authentication works",
+{
+    outl <- get_personal_outlook(token=tok)
+    expect_is(outl, "ms_outlook")
+
+    outl2 <- get_personal_outlook(app=app)
+    expect_is(outl2, "ms_outlook")
+    expect_identical(outl$properties$id, outl2$properties$id)
+})

--- a/tests/testthat/test04a_channel.R
+++ b/tests/testthat/test04a_channel.R
@@ -13,24 +13,20 @@ if(Sys.getenv("AZ_TEST_CHANNEL_FLAG") == "")
 if(!interactive())
     skip("Channel tests skipped: must be in interactive session")
 
-tok <- try(AzureAuth::get_azure_token(
-    c("https://graph.microsoft.com/.default",
-      "openid",
-      "offline_access"),
-    tenant=tenant, app=app, version=2),
-    silent=TRUE)
-if(inherits(tok, "try-error"))
+tok <- get_test_token(tenant, app, c("Group.ReadWrite.All", "Directory.Read.All"))
+if(is.null(tok))
     skip("Channel tests skipped: no access to tenant")
 
 team <- try(call_graph_endpoint(tok, file.path("teams", team_id)), silent=TRUE)
 if(inherits(team, "try-error"))
     skip("Channel tests skipped: service not available")
 
+team <- ms_team$new(tok, tenant, team)
+
 channel_name <- sprintf("Test channel %s", make_name(10))
 
 test_that("Channel methods work",
 {
-    team <- get_team(team_id=team_id, tenant=tenant, app=app)
     expect_is(team, "ms_team")
 
     expect_error(team$get_channel(channel_name=channel_name))

--- a/tests/testthat/test05_outlook.R
+++ b/tests/testthat/test05_outlook.R
@@ -1,3 +1,4 @@
+tenant <- "consumers"
 app <- Sys.getenv("AZ_TEST_NATIVE_APP_ID")
 
 if(app == "")
@@ -6,23 +7,19 @@ if(app == "")
 if(!interactive())
     skip("Outlook tests skipped: must be in interactive session")
 
-tok <- try(AzureAuth::get_azure_token(c("https://graph.microsoft.com/Mail.Read", "openid", "offline_access"),
-    tenant="9188040d-6c67-4c5b-b112-36a304b66dad", app=.microsoft365r_app_id, version=2),
-    silent=TRUE)
-if(inherits(tok, "try-error"))
+tok <- get_test_token(tenant, app, c("Mail.Send", "Mail.ReadWrite", "User.Read"))
+if(is.null(tok))
     skip("Outlook tests skipped: unable to login to consumers tenant")
 
 inbox <- try(call_graph_endpoint(tok, "me/mailFolders/inbox"), silent=TRUE)
 if(inherits(inbox, "try-error"))
     skip("Outlook tests skipped: service not available")
 
+outl <- get_personal_outlook(token=tok)
+
 test_that("Outlook client works",
 {
-    outl <- get_personal_outlook()
     expect_is(outl, c("ms_outlook", "ms_outlook_object"))
-
-    outl2 <- get_personal_outlook(app=app)
-    expect_is(outl2, c("ms_outlook", "ms_outlook_object"))
 
     folders <- outl$list_folders()
     expect_is(folders, "list")

--- a/tests/testthat/test05a_outlook_folder.R
+++ b/tests/testthat/test05a_outlook_folder.R
@@ -1,3 +1,4 @@
+tenant <- "consumers"
 app <- Sys.getenv("AZ_TEST_NATIVE_APP_ID")
 
 if(app == "")
@@ -6,19 +7,18 @@ if(app == "")
 if(!interactive())
     skip("Outlook folder tests skipped: must be in interactive session")
 
-tok <- try(AzureAuth::get_azure_token(c("https://graph.microsoft.com/Mail.Read", "openid", "offline_access"),
-    tenant="9188040d-6c67-4c5b-b112-36a304b66dad", app=.microsoft365r_app_id, version=2),
-    silent=TRUE)
-if(inherits(tok, "try-error"))
+tok <- get_test_token(tenant, app, c("Mail.Send", "Mail.ReadWrite", "User.Read"))
+if(is.null(tok))
     skip("Outlook tests skipped: unable to login to consumers tenant")
 
 inbox <- try(call_graph_endpoint(tok, "me/mailFolders/inbox"), silent=TRUE)
 if(inherits(inbox, "try-error"))
     skip("Outlook tests skipped: service not available")
 
+outl <- get_personal_outlook(token=tok)
+
 test_that("Outlook folder methods work",
 {
-    outl <- get_personal_outlook()
     expect_is(outl, c("ms_outlook", "ms_outlook_object"))
 
     fname <- make_name()

--- a/tests/testthat/test05b_outlook_email.R
+++ b/tests/testthat/test05b_outlook_email.R
@@ -1,3 +1,4 @@
+tenant <- "consumers"
 app <- Sys.getenv("AZ_TEST_NATIVE_APP_ID")
 from_addr <- Sys.getenv("AZ_TEST_OUTLOOK_FROM_ADDR")
 to_addr <- Sys.getenv("AZ_TEST_OUTLOOK_TO_ADDR")
@@ -10,10 +11,8 @@ if(app == "" || from_addr == "" || to_addr == "" || cc_addr == "" || bcc_addr ==
 if(!interactive())
     skip("Outlook email tests skipped: must be in interactive session")
 
-tok <- try(AzureAuth::get_azure_token(c("https://graph.microsoft.com/Mail.Read", "openid", "offline_access"),
-    tenant="9188040d-6c67-4c5b-b112-36a304b66dad", app=.microsoft365r_app_id, version=2),
-    silent=TRUE)
-if(inherits(tok, "try-error"))
+tok <- get_test_token(tenant, app, c("Mail.Send", "Mail.ReadWrite", "User.Read"))
+if(is.null(tok))
     skip("Outlook tests skipped: unable to login to consumers tenant")
 
 inbox <- try(call_graph_endpoint(tok, "me/mailFolders/inbox"), silent=TRUE)
@@ -26,7 +25,7 @@ get_bcc_addr <- function(x, n=1) x$properties$bccRecipients[[n]]$emailAddress$ad
 get_replyto_addr <- function(x, n=1) x$properties$replyTo[[n]]$emailAddress$address
 
 fname <- make_name()
-folder <- get_personal_outlook()$create_folder(fname)
+folder <- get_personal_outlook(token=tok)$create_folder(fname)
 
 test_that("Outlook email methods work",
 {

--- a/tests/testthat/test05c_outlook_attachment.R
+++ b/tests/testthat/test05c_outlook_attachment.R
@@ -1,3 +1,4 @@
+tenant <- "consumers"
 app <- Sys.getenv("AZ_TEST_NATIVE_APP_ID")
 to_addr <- Sys.getenv("AZ_TEST_OUTLOOK_TO_ADDR")
 cc_addr <- Sys.getenv("AZ_TEST_OUTLOOK_CC_ADDR")
@@ -9,22 +10,16 @@ if(app == "" || to_addr == "" || cc_addr == "" || bcc_addr == "")
 if(!interactive())
     skip("Outlook email attachment tests skipped: must be in interactive session")
 
-tok <- try(AzureAuth::get_azure_token(c("https://graph.microsoft.com/Mail.Read", "openid", "offline_access"),
-    tenant="9188040d-6c67-4c5b-b112-36a304b66dad", app=.microsoft365r_app_id, version=2),
-    silent=TRUE)
-if(inherits(tok, "try-error"))
+tok <- get_test_token(tenant, app, c("Mail.Send", "Mail.ReadWrite", "User.Read"))
+if(is.null(tok))
     skip("Outlook email attachment tests skipped: unable to login to consumers tenant")
 
 inbox <- try(call_graph_endpoint(tok, "me/mailFolders/inbox"), silent=TRUE)
 if(inherits(inbox, "try-error"))
     skip("Outlook email attachment tests skipped: service not available")
 
-inbox <- try(call_graph_endpoint(tok, "me/mailFolders/inbox"), silent=TRUE)
-if(inherits(inbox, "try-error"))
-    skip("Outlook email attachment tests skipped: service not available")
-
 fname <- make_name()
-folder <- get_personal_outlook()$create_folder(fname)
+folder <- get_personal_outlook(token=tok)$create_folder(fname)
 
 test_that("Outlook email attachment methods work",
 {

--- a/tests/testthat/test05d_outlook_send.R
+++ b/tests/testthat/test05d_outlook_send.R
@@ -1,3 +1,4 @@
+tenant <- "consumers"
 app <- Sys.getenv("AZ_TEST_NATIVE_APP_ID")
 from_addr <- Sys.getenv("AZ_TEST_OUTLOOK_FROM_ADDR")
 to_addr <- Sys.getenv("AZ_TEST_OUTLOOK_TO_ADDR")
@@ -10,10 +11,8 @@ if(app == "" || from_addr == "" || to_addr == "" || cc_addr == "" || bcc_addr ==
 if(!interactive())
     skip("Outlook email send tests skipped: must be in interactive session")
 
-tok <- try(AzureAuth::get_azure_token(c("https://graph.microsoft.com/Mail.Read", "openid", "offline_access"),
-    tenant="9188040d-6c67-4c5b-b112-36a304b66dad", app=.microsoft365r_app_id, version=2),
-    silent=TRUE)
-if(inherits(tok, "try-error"))
+tok <- get_test_token(tenant, app, c("Mail.Send", "Mail.ReadWrite", "User.Read"))
+if(is.null(tok))
     skip("Outlook tests send skipped: unable to login to consumers tenant")
 
 inbox <- try(call_graph_endpoint(tok, "me/mailFolders/inbox"), silent=TRUE)
@@ -26,7 +25,7 @@ get_bcc_addr <- function(x, n=1) x$properties$bccRecipients[[n]]$emailAddress$ad
 get_replyto_addr <- function(x, n=1) x$properties$replyTo[[n]]$emailAddress$address
 
 fname <- make_name()
-outl <- get_personal_outlook()
+outl <- get_personal_outlook(token=tok)
 folder <- outl$create_folder(fname)
 
 test_that("Outlook email sending methods work",

--- a/tests/testthat/test05e_outlook_copymove.R
+++ b/tests/testthat/test05e_outlook_copymove.R
@@ -1,3 +1,4 @@
+tenant <- "consumers"
 app <- Sys.getenv("AZ_TEST_NATIVE_APP_ID")
 from_addr <- Sys.getenv("AZ_TEST_OUTLOOK_FROM_ADDR")
 to_addr <- Sys.getenv("AZ_TEST_OUTLOOK_TO_ADDR")
@@ -10,10 +11,8 @@ if(app == "" || from_addr == "" || to_addr == "" || cc_addr == "" || bcc_addr ==
 if(!interactive())
     skip("Outlook email send tests skipped: must be in interactive session")
 
-tok <- try(AzureAuth::get_azure_token(c("https://graph.microsoft.com/Mail.Read", "openid", "offline_access"),
-    tenant="9188040d-6c67-4c5b-b112-36a304b66dad", app=.microsoft365r_app_id, version=2),
-    silent=TRUE)
-if(inherits(tok, "try-error"))
+tok <- get_test_token(tenant, app, c("Mail.Send", "Mail.ReadWrite", "User.Read"))
+if(is.null(tok))
     skip("Outlook tests send skipped: unable to login to consumers tenant")
 
 get_to_addr <- function(x, n=1) x$properties$toRecipients[[n]]$emailAddress$address
@@ -21,7 +20,7 @@ get_cc_addr <- function(x, n=1) x$properties$ccRecipients[[n]]$emailAddress$addr
 get_bcc_addr <- function(x, n=1) x$properties$bccRecipients[[n]]$emailAddress$address
 get_replyto_addr <- function(x, n=1) x$properties$replyTo[[n]]$emailAddress$address
 
-outl <- get_personal_outlook()
+outl <- get_personal_outlook(token=tok)
 srcname <- make_name()
 destname <- make_name()
 src <- outl$create_folder(srcname)

--- a/tests/testthat/test06_planner.R
+++ b/tests/testthat/test06_planner.R
@@ -9,22 +9,19 @@ if(tenant == "" || app == "" || site_url == "" || site_id == "")
 if(!interactive())
     skip("Planner tests skipped: must be in interactive session")
 
-tok <- try(AzureAuth::get_azure_token(
-    c("https://graph.microsoft.com/.default",
-      "openid",
-      "offline_access"),
-    tenant=tenant, app=app, version=2),
-    silent=TRUE)
-if(inherits(tok, "try-error"))
+tok <- get_test_token(tenant, app, c("Group.ReadWrite.All", "Directory.Read.All",
+                                     "Sites.ReadWrite.All", "Sites.Manage.All"))
+if(is.null(tok))
     skip("Planner tests skipped: no access to tenant")
 
 site <- try(call_graph_endpoint(tok, file.path("sites", site_id)), silent=TRUE)
 if(inherits(site, "try-error"))
     skip("Planner tests skipped: service not available")
 
+site <- ms_site$new(tok, tenant, site)
+
 test_that("Planner methods work",
 {
-    site <- get_sharepoint_site(site_url=site_url, tenant=tenant, app=app)
     expect_is(site, "ms_site")
 
     grp <- site$get_group()

--- a/vignettes/auth.Rmd
+++ b/vignettes/auth.Rmd
@@ -3,9 +3,9 @@ title: "Authenticating to Microsoft 365"
 author: Hong Ooi
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Authentication}
-  %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{utf8}
+    %\VignetteIndexEntry{Authentication}
+    %\VignetteEngine{knitr::rmarkdown}
+    %\VignetteEncoding{utf8}
 ---
 
 ## Authentication
@@ -50,7 +50,9 @@ For authentication purposes, the package is registered as an app in the 'aicatr'
 
 ### Using your own app registration
 
-Rather than getting the Microsoft365R app approved, you can also use your own app registration for authentication. If you want to use the default authorization code flow, the app registration should have a mobile & desktop redirect URI of `https://localhost:1410` (not a web or SPA redirect). If you want to use the device code flow, the "Allow native client" setting should be enabled. Your app should also have the same default permissions as the Microsoft365R app (see above).
+Rather than getting the Microsoft365R app approved, you can also use your own app registration for authentication. One specific scenario where this is **required** if you want to use Microsoft365R with Shiny---see the vignette "Using Microsoft365R in a Shiny app" for more on this topic, including how to configure the app registration in Azure Active Directory.
+
+For use in a local R session, if you want to use the default authorization code flow, the app registration should have a mobile & desktop redirect URI of `https://localhost:1410` (not a web or SPA redirect). If you want to use the device code flow, the "Allow native client" setting should be enabled. Your app should also have the same default permissions as the Microsoft365R app (see above).
 
 Once the app has been registered, you can pass the app ID to Microsoft365R in a couple of ways.
 
@@ -80,6 +82,26 @@ The above methods are the **recommended solutions** to dealing with access restr
   ```
 
 Be warned that these workarounds may draw the attention of your admin!
+
+
+## Authenticating with a token
+
+In some circumstances, it may be desirable to carry out authentication/authorization as a separate step prior to  making requests to the Microsoft 365 REST API. This holds in a Shiny app, for example, since only the UI part can talk to the browser while the server part does the rest of the work. Another scenario is if the refresh token lifetime set by your org is too short, so that the token expires in between R sessions. In this case, you can authenticate by obtaining a new token with `AzureAuth::get_azure_token`, and passing the token object to the client function.
+
+When calling `get_azure_token`, the scopes you should use are those given in the `scopes` argument for each client function, and the API host is `https://graph.microsoft.com/`. The Microsoft365R internal app ID is `d44a05d5-c6a5-4bbb-82d2-443123722380`, while that for the CLI for Microsoft 365 is `31359c7f-bd7e-475c-86db-fdb8c937548e`. As noted above, however, these app IDs **only** work for a local R session; you must create your own app registration if you want to use the package inside a Shiny app.
+
+```r
+# authenticating separately to working with the MS365 API
+scopes <- c(
+    "https://graph.microsoft.com/Files.ReadWrite.All",
+    "https://graph.microsoft.com/User.Read",
+    "openid", "offline_access"
+)
+app <- "d44a05d5-c6a5-4bbb-82d2-443123722380" # for local use only
+token <- AzureAuth::get_azure_token(scopes, "mytenant", app, version=2)
+od <- get_business_onedrive(token=token)
+```
+
 
 ## Other issues
 

--- a/vignettes/shiny.Rmd
+++ b/vignettes/shiny.Rmd
@@ -3,7 +3,7 @@ title: "Using Microsoft365R in a Shiny app"
 author: Hong Ooi
 output: rmarkdown::html_vignette
 vignette: >
-    %\VignetteIndexEntry{Shiny}
+    %\VignetteIndexEntry{Microsoft365R and Shiny}
     %\VignetteEngine{knitr::rmarkdown}
     %\VignetteEncoding{utf8}
 ---


### PR DESCRIPTION
- make `token` an explicit argument to client functions
- remove caching of logins, which is obsolete since each client now uses different permissions
- closes #84, fixes #80