### PR TITLE
Fix error on R 4.3, warning on R <= 4.2: `'length = 3' in coercion to 'logical(1)'`

### DIFF
--- a/R/build_email_request.R
+++ b/R/build_email_request.R
@@ -81,7 +81,7 @@ build_email_recipients <- function(to, cc, bcc, reply_to)
     make_recipients <- function(addr_list)
     {
         # NA means don't update current value
-        if(!is_empty(addr_list) && is.na(addr_list))
+        if(!is_empty(addr_list) && all(is.na(addr_list)))
             return(NA)
 
         # handle case of a single az_user object


### PR DESCRIPTION
This throws an error `'length = 3' in coercion to 'logical(1)'` if `addr_list` is length > 1.