### PR TITLE
Fix redirect URI in documentation

### DIFF
--- a/vignettes/auth.Rmd
+++ b/vignettes/auth.Rmd
@@ -50,7 +50,7 @@ Microsoft365R comes with a default app registration for authenticating with AAD;
 
 ### Using your own app registration
 
-Rather than getting the default app registration approved, you can also create your own registration for authentication. If this is for use in a local R session, it should have a mobile & desktop redirect URI of `https://localhost:1410` (not a web or SPA redirect), and the "Allow native client" setting should be enabled. You can use the same permissions as the default app, or set your own: for example, if you know you don't need to interact with Outlook, you can omit the Mail.Send and Mail.ReadWrite permissions.
+Rather than getting the default app registration approved, you can also create your own registration for authentication. If this is for use in a local R session, it should have a mobile & desktop redirect URI of `http://localhost:1410` (not a web or SPA redirect), and the "Allow native client" setting should be enabled. You can use the same permissions as the default app, or set your own: for example, if you know you don't need to interact with Outlook, you can omit the Mail.Send and Mail.ReadWrite permissions.
 
 Once the app has been registered, you can pass the app ID to Microsoft365R in a couple of ways.
 


### PR DESCRIPTION
If the redirect URI of `https://localhost:1410` is configured, this will not work correctly.

The underlying function call within AzureAuth uses `http://localhost:1410`, hence this should be the redirect URI added to the configuration.

See the default options within the [relevant function](https://github.com/Azure/AzureAuth/blob/f6e54d77089d37fa42d437d6dc56c9917282c41a/R/flow_init.R#L56).