### PR TITLE
Update scripted.Rmd

### DIFF
--- a/vignettes/scripted.Rmd
+++ b/vignettes/scripted.Rmd
@@ -134,6 +134,7 @@ tenant <- "your-tenant-here"
 
 # the application/client ID of the app registration to use
 app <- "your-app-id-here"
+app_secret <- "your-app-secret-here"
 
 # get the service account username and password
 user <- Sys.getenv("EXAMPLE_MS365R_SERVICE_USER")
@@ -144,7 +145,7 @@ target_drive <- Sys.getenv("EXAMPLE_MS365R_TARGET_DRIVE")
 target_path <- Sys.getenv("EXAMPLE_MS365R_TARGET_PATH")
 
 drv <- get_business_onedrive(tenant=tenant, app=app, username=user, password=pwd,
-    auth_type="resource_owner")
+    token_args = list(client_secret = app_secret), auth_type="resource_owner")
 
 # search for the desired item in the list of shared items
 shared <- drv$list_shared_files(info="items")


### PR DESCRIPTION
The current Microsoft Graph API requires a client_secret to be passed along when an app id is being referenced for a resource_owner auth flow.